### PR TITLE
Added support for iterable input instead of file

### DIFF
--- a/tests/test_zipstream.py
+++ b/tests/test_zipstream.py
@@ -50,10 +50,33 @@ class ZipStreamTestCase(unittest.TestCase):
         f.close()
 
         z2 = zipfile.ZipFile(f.name, 'r')
-        z2.testzip()
+        self.assertFalse(z2.testzip())
 
         os.remove(f.name)
 
+    def test_write_iterable(self):
+        z = zipstream.ZipFile(mode='w')
+        def string_generator():
+            for _ in range(10):
+                yield b'zipstream\x01\n'
+        data = [string_generator(), string_generator()]
+        for i, d in enumerate(data):
+            z.write_iter(iterable=d, arcname='data_{0}'.format(i))
+
+        f = tempfile.NamedTemporaryFile(suffix='zip', delete=False)
+        for chunk in z:
+            f.write(chunk)
+        f.close()
+
+        z2 = zipfile.ZipFile(f.name, 'r')
+        self.assertFalse(z2.testzip())
+
+        os.remove(f.name)
+
+
+    def test_write_iterable_no_archive(self):
+        z = zipstream.ZipFile(mode='w')
+        self.assertRaises(TypeError, z.write_iter, iterable=range(10))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added the support for writing an iterable to the zip archive.

This can be useful when you have a very large file (typically resulting from a large database request). In this case you may want to split your request in several requests (pagination) and write them separately to the archive without creating a huge file in memory or on the disk.
