### PR TITLE
Write path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@
 zipstream.py is a zip archive generator based on python 3.3's zipfile.py. It was created to
 generate a zip file generator for streaming (ie web apps). This is beneficial for when you 
 want to provide a downloadable archive of a large collection of regular files, which would be infeasible to
-generate the archive prior to downloading.
+generate the archive prior to downloading or of a very large file that you do not want to store entirely on disk or on memory.
 
 The archive is generated as an iterator of strings, which, when joined, form
 the zip archive. For example, the following code snippet would write a zip
@@ -15,7 +15,36 @@ archive containing files from 'path' to a normal file:
 
 ```python
 zf = open('zipfile.zip', 'wb')
-for data in ZipStream(path):
+for data in zipstream.ZipFile(path):
+    zf.write(data)
+zf.close()
+```
+
+zipstream also allows to take as input a byte string iterable and to generate
+the archive as an iterator.
+This avoids storing large files on disk or in memory.
+To do so you could use something like this snippet:
+
+```python
+def iterable():
+    for _ in xrange(10):
+        yield b'this is a byte string\x01\n'
+
+zf = open('zipfile.zip', 'wb')
+zf.write_iter('my_archive_name', iterable())
+zf.close()
+```
+
+Of course both approach can be combined:
+
+```python
+def iterable():
+    for _ in xrange(10):
+        yield b'this is a byte string\x01\n'
+
+zf = open('zipfile.zip', 'wb')
+zf.write_iter('my_archive_name', iterable())
+for data in zipstream.ZipFile(path):
     zf.write(data)
 zf.close()
 ```
@@ -31,10 +60,10 @@ def GET(self):
     web.header('Content-type' , 'application/zip')
     web.header('Content-Disposition', 'attachment; filename="%s"' % (
         zip_filename,))
-    return ZipStream(path)
+    return zipstream.ZipFile(path)
 ```
 
-If the zlib module is available, ZipStream can generate compressed zip
+If the zlib module is available, zipstream.ZipFile can generate compressed zip
 archives.
 
 ## Requirements
@@ -51,7 +80,7 @@ from flask import Response
 @app.route('/package.zip', methods=['GET'], endpoint='zipball')
 def zipball():
     def generator():
-    	z = ZipStream(mode='w', compression=ZIP_DEFLATED)
+    	z = zipstream.ZipFile(mode='w', compression=ZIP_DEFLATED)
 
     	z.write('/path/to/file')
 
@@ -66,7 +95,7 @@ def zipball():
 
 @app.route('/package.zip', methods=['GET'], endpoint='zipball')
 def zipball():
-	z = ZipStream(mode='w', compression=ZIP_DEFLATED)
+	z = zipstream.ZipFile(mode='w', compression=ZIP_DEFLATED)
 	z.write('/path/to/file')
 
     response = Response(z, mimetype='application/zip')
@@ -80,7 +109,7 @@ def zipball():
 from django.http import StreamingHttpResponse
 
 def zipball(request):
-	z = ZipStream(mode='w', compression=ZIP_DEFLATED)
+	z = zipstream.ZipFile(mode='w', compression=ZIP_DEFLATED)
 	z.write('/path/to/file')
 
     response = StreamingHttpResponse(z, mimetype='application/zip')
@@ -97,5 +126,11 @@ def GET(self):
     web.header('Content-type' , 'application/zip')
     web.header('Content-Disposition', 'attachment; filename="%s"' % (
         zip_filename,))
-    return ZipStream(path)
+    return zipstream.ZipFile(path)
 ```
+
+## Running tests
+    
+With python version > 2.6, just run the following command: `python -m unittest discover`
+
+Alternatively, you can use `nose`.

--- a/example.py
+++ b/example.py
@@ -14,6 +14,8 @@ with zipstream.ZipFile(mode='w', compression=zipstream.ZIP_DEFLATED) as z:
             path = os.path.join(root, filename)
             z.write(path, path)
 
+    z.write('tests')
+
     with open('test.zip', 'wb') as f:
         for chunk in z:
             f.write(chunk)

--- a/tests/test_zipstream.py
+++ b/tests/test_zipstream.py
@@ -50,10 +50,33 @@ class ZipStreamTestCase(unittest.TestCase):
         f.close()
 
         z2 = zipfile.ZipFile(f.name, 'r')
-        z2.testzip()
+        self.assertFalse(z2.testzip())
 
         os.remove(f.name)
 
+    def test_write_iterable(self):
+        z = zipstream.ZipFile(mode='w')
+        def string_generator():
+            for _ in range(10):
+                yield b'zipstream\x01\n'
+        data = [string_generator(), string_generator()]
+        for i, d in enumerate(data):
+            z.write_iter(iterable=d, arcname='data_{0}'.format(i))
+
+        f = tempfile.NamedTemporaryFile(suffix='zip', delete=False)
+        for chunk in z:
+            f.write(chunk)
+        f.close()
+
+        z2 = zipfile.ZipFile(f.name, 'r')
+        self.assertFalse(z2.testzip())
+
+        os.remove(f.name)
+
+
+    def test_write_iterable_no_archive(self):
+        z = zipstream.ZipFile(mode='w')
+        self.assertRaises(TypeError, z.write_iter, iterable=range(10))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Another pull request to add the support of paths in addition to a simple filename in `zipstream.ZipFile.write`
You can then add a complete directory to the archive with a simple call to `zipstream.ZipFile.write('path/to/my/directory')`