### PR TITLE
remove tests directory from build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Allan Lei',
     author_email='allanlei@helveticode.com',
     url='https://github.com/allanlei/python-zipstream',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     keywords='zip streaming',
 
     test_suite='nose.collector',


### PR DESCRIPTION
Hello,

Would it be possible to merge this PR. It removes the tests directory from the builded package uploaded to pypi, which could be useful when the package is used in production.

Thanks