### PR TITLE
Run filesize comparisons if not running in streaming mode.

### DIFF
--- a/zipstream/__init__.py
+++ b/zipstream/__init__.py
@@ -324,7 +324,8 @@ class ZipFile(zipfile.ZipFile):
             zinfo.compress_size = file_size
         zinfo.CRC = CRC
         zinfo.file_size = file_size
-        if not zip64 and self._allowZip64:
+        # Run these checks if not running in streaming mode i.e. filename is provided
+        if not zip64 and self._allowZip64 and filename:
             if file_size > ZIP64_LIMIT:
                 raise RuntimeError('File size has increased during compressing')
             if compress_size > ZIP64_LIMIT:


### PR DESCRIPTION
When streaming zip content using SMBHandler and not writing the data to a file(streaming data out instead), the check at https://github.com/allanlei/python-zipstream/blob/master/zipstream/__init__.py#L328 detects that the data transferred (filesize) is greater than ZIP64_LIMIT. The Zip64 flag even after being set during initialization, has the variable zip64 set to False which cause the RuntimeError 'File size has increased during compressing'.

This is my proposed solution: We should only check the file size or the compress size when we are writing to a file i.e. filename is specified.

This solution works for my use case where I am streaming in/out data but I leave the actual implementation to fix this bug to the authors.