### PR TITLE
Add possibility to add empty directories to archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
   - "3.5"
-  - "pypy"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 install:
   - "pip install ."
 script: nosetests

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+# Deprecated ⚠️
+Moved to: https://github.com/saritasa-nest/usummit-python-zipstream
 
 # python-zipstream
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, pypy
+envlist = py35, py36, py37, py38, py39
 
 [testenv]
 deps=nose

--- a/zipstream/__init__.py
+++ b/zipstream/__init__.py
@@ -243,7 +243,8 @@ class ZipFile(zipfile.ZipFile):
             mtime = time.localtime(st.st_mtime)
             date_time = mtime[0:6]
         else:
-            st, isdir, date_time = None, False, time.localtime()[0:6]
+            st, date_time = None, time.localtime()[0:6]
+            isdir = arcname[-1] == os.sep
         # Create ZipInfo instance to store file information
         if arcname is None:
             arcname = filename

--- a/zipstream/__init__.py
+++ b/zipstream/__init__.py
@@ -281,6 +281,9 @@ class ZipFile(zipfile.ZipFile):
             zinfo.file_size = 0
             zinfo.compress_size = 0
             zinfo.CRC = 0
+            # use `0` bits flag for folders - because of bug with opening
+            # archives with folders ZipInfo on macOS (couldn't be decompressed)
+            zinfo.flag_bits = 0
             self.filelist.append(zinfo)
             self.NameToInfo[zinfo.filename] = zinfo
             yield self.fp.write(zinfo.FileHeader(False))

--- a/zipstream/__init__.py
+++ b/zipstream/__init__.py
@@ -257,7 +257,7 @@ class ZipFile(zipfile.ZipFile):
         if st:
             zinfo.external_attr = (st[0] & 0xFFFF) << 16      # Unix attributes
         else:
-            zinfo.external_attr = 0o600 << 16     # ?rw-------
+            zinfo.external_attr = 0o777 << 16  # ?drwxr-xr-x
         if compress_type is None:
             zinfo.compress_type = self.compression
         else:
@@ -284,6 +284,7 @@ class ZipFile(zipfile.ZipFile):
             # use `0` bits flag for folders - because of bug with opening
             # archives with folders ZipInfo on macOS (couldn't be decompressed)
             zinfo.flag_bits = 0
+            zinfo.external_attr |= 0x10  # MS-DOS directory flag
             self.filelist.append(zinfo)
             self.NameToInfo[zinfo.filename] = zinfo
             yield self.fp.write(zinfo.FileHeader(False))


### PR DESCRIPTION
There was no possibility to add empty directories to archive, added it.
If `arcname` ends with os path separator (e.g. '\'), it will be written to archive as a directory.